### PR TITLE
Add missing Makefile dependency, pdbApp must follow configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ DIRS += configure
 DIRS += $(wildcard *App)
 DIRS += $(wildcard iocBoot)
 
+# pdbApp depends on configure for CONFIG_QSRV_VERSION
+pdbApp_DEPEND_DIRS = configure
+
 # iocBoot depends on all *App dirs
 iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 testApp_DEPEND_DIRS += p2pApp pdbApp


### PR DESCRIPTION
The pdbApp/Makefile needs `$(EPICS_QSRV_ABI_MAJOR_VERSION)` and `$(EPICS_QSRV_ABI_MINOR_VERSION)` which will only be set if pdbApp/Makefile is parsed after configure/Makefile has installed the CONFIG_QSRV_VERSION into cfg.