### PR TITLE
Add Makefile rule for qsrv.dbd.d to avoid spurious build warning

### DIFF
--- a/pdbApp/Makefile
+++ b/pdbApp/Makefile
@@ -99,5 +99,8 @@ else
 ../O.Common/qsrv.dbd: ../qsrv-old.dbd
 	$(CP) $< $@
 endif
+qsrv.dbd$(DEP):
+	@$(RM) $@
+	@echo "$(COMMONDEP_TARGET): ../Makefile" > $@
 
 ../O.Common/softIocPVA.dbd: ../O.Common/qsrv.dbd


### PR DESCRIPTION
Prevents "dbdExpand.pl: No input files for ../O.Common/qsrv.dbd"