### PR TITLE
create second dbChannel for DBE_PROPERTY

### DIFF
--- a/pdbApp/pdb.cpp
+++ b/pdbApp/pdb.cpp
@@ -419,6 +419,12 @@ PDBProvider::PDBProvider(const epics::pvAccess::Configuration::const_shared_poin
                     members_map[mem.pvfldname] = J;
                     PDBGroupPV::Info& info = members[J];
 
+                    DBCH chan2;
+                    if(chan.chan && (ellCount(&chan.chan->pre_chain)>0 || ellCount(&chan.chan->post_chain)>0)) {
+                        DBCH temp(mem.pvname);
+                        info.chan2.swap(chan2);
+                    }
+
                     info.allowProc = mem.putorder != std::numeric_limits<int>::min();
                     info.builder = PTRMOVE(mem.builder);
                     assert(info.builder.get());
@@ -514,7 +520,8 @@ PDBProvider::PDBProvider(const epics::pvAccess::Configuration::const_shared_poin
                 info.pvif.reset(info.builder->attach(info.chan, pv->complete, info.attachment));
 
                 // TODO: don't need evt_PROPERTY for PVIF plain
-                info.evt_PROPERTY.create(event_context, info.chan, &pdb_group_event, DBE_PROPERTY);
+                dbChannel *pchan = info.chan2.chan ? info.chan2.chan : info.chan.chan;
+                info.evt_PROPERTY.create(event_context, pchan, &pdb_group_event, DBE_PROPERTY);
 
                 if(!info.triggers.empty()) {
                     info.evt_VALUE.create(event_context, info.chan, &pdb_group_event, DBE_VALUE|DBE_ALARM);

--- a/pdbApp/pdbgroup.h
+++ b/pdbApp/pdbgroup.h
@@ -87,6 +87,8 @@ struct QSRV_API PDBGroupPV : public PDBPV
 
     struct Info {
         DBCH chan;
+        // used for DBE_PROPERTY subscription when chan has filters
+        DBCH chan2;
         std::tr1::shared_ptr<PVIFBuilder> builder;
         FieldName attachment;
         typedef std::vector<size_t> triggers_t;

--- a/pdbApp/pdbsingle.cpp
+++ b/pdbApp/pdbsingle.cpp
@@ -103,6 +103,10 @@ PDBSinglePV::PDBSinglePV(DBCH& chan,
     ,hadevent_VALUE(false)
     ,hadevent_PROPERTY(false)
 {
+    if(ellCount(&chan.chan->pre_chain) || ellCount(&chan.chan->post_chain)) {
+        DBCH temp(dbChannelName(chan.chan));
+        this->chan2.swap(temp);
+    }
     this->chan.swap(chan);
     fielddesc = std::tr1::static_pointer_cast<const pvd::Structure>(builder->dtype(this->chan));
 
@@ -120,8 +124,9 @@ PDBSinglePV::~PDBSinglePV()
 
 void PDBSinglePV::activate()
 {
+    dbChannel *pchan = this->chan2.chan ? this->chan2.chan : this->chan.chan;
     evt_VALUE.create(provider->event_context, this->chan, &pdb_single_event, DBE_VALUE|DBE_ALARM);
-    evt_PROPERTY.create(provider->event_context, this->chan, &pdb_single_event, DBE_PROPERTY);
+    evt_PROPERTY.create(provider->event_context, pchan, &pdb_single_event, DBE_PROPERTY);
 }
 
 pva::Channel::shared_pointer

--- a/pdbApp/pdbsingle.h
+++ b/pdbApp/pdbsingle.h
@@ -30,6 +30,8 @@ struct QSRV_API PDBSinglePV : public PDBPV
      * is locked.
      */
     DBCH chan;
+    // used for DBE_PROPERTY subscription when chan has filters
+    DBCH chan2;
     PDBProvider::shared_pointer provider;
 
     // only for use in pdb_single_event()


### PR DESCRIPTION
Attempt to fix #32.  Create second channel, and second set of filter states, for subscription to DBE_PROPERTY.  Accommodate filters which drop events.