### PR TITLE
Modify testpvalink.db to avoid breakage when json5 merged

### DIFF
--- a/testApp/testpvalink.db
+++ b/testApp/testpvalink.db
@@ -8,7 +8,7 @@ record(ai, "target:ai") {
 }
 
 record(int64in, "src:i1") {
-    field(INP, {pva:"target:i"})
+    field(INP, {"pva":"target:i"})
 }
 
 # used by testPut()
@@ -17,5 +17,5 @@ record(int64in, "target:i2") {
 }
 
 record(int64out, "src:o2") {
-    field(OUT, {pva:"target:i2"})
+    field(OUT, {"pva":"target:i2"})
 }


### PR DESCRIPTION
No other changes will be needed when merging the json5 branch into
Base-7.0, these changes let testpvalink pass with and without it.