### PR TITLE
Syncing softMain.cpp with epics-base

### DIFF
--- a/pdbApp/softMain.cpp
+++ b/pdbApp/softMain.cpp
@@ -136,6 +136,7 @@ int main(int argc, char *argv[])
                     xmacro;
         bool interactive = true;
         bool loadedDb = false;
+        bool ranScript = false;
 
 #ifdef USE_EXECDIR
         // attempt to compute relative paths
@@ -240,7 +241,7 @@ int main(int argc, char *argv[])
                 std::cout<<"# End "<<argv[optind]<<"\n";
 
             epicsThreadSleep(0.2);
-            loadedDb = true;    /* Give it the benefit of the doubt... */
+            ranScript = true;    /* Assume the script has done any necessary initialization */
         }
 
         if (loadedDb) {
@@ -259,7 +260,7 @@ int main(int argc, char *argv[])
             }
 
         } else {
-            if (loadedDb) {
+            if (loadedDb || ranScript) {
                 epicsThreadExitMain();
 
             } else {


### PR DESCRIPTION
In commit https://github.com/epics-base/epics-base/commit/b890d584bce92d8374ca76d09a68c49f9a8fad05 from EPICS base, an issue was fixed where iocInit would be called twice, producing an unnecessary warning.

This simply syncs the two files to get rid of that warning.

Note that a better fix should be chosen at some point in the future to avoid this issue later on. However, the purpose of this change is simply to get rid of the warning.