### PR TITLE
enable "Async Soft Channel" for output links

### DIFF
--- a/pdbApp/pvalink.cpp
+++ b/pdbApp/pvalink.cpp
@@ -251,7 +251,7 @@ void dbpvar(const char *precordname, int level)
                        chan->connected_latched?'T':'F',
                        chan->num_disconnect,
                        chan->num_type_change);
-                if(chan->op_put.valid()) {
+                if(chan->put_in_progress) {
                     printf(" Put");
                 }
 

--- a/pdbApp/pvalink.h
+++ b/pdbApp/pvalink.h
@@ -154,6 +154,8 @@ struct pvaLinkChannel : public pvac::ClientChannel::MonitorCallback,
     bool queued; // added to WorkQueue
     bool debug; // set if any jlink::debug is set
     std::tr1::shared_ptr<const void> previous_root;
+    typedef std::set<dbCommon*> after_put_t;
+    after_put_t after_put;
 
     struct LinkSort {
         bool operator()(const pvaLink *L, const pvaLink *R) const;
@@ -180,6 +182,12 @@ struct pvaLinkChannel : public pvac::ClientChannel::MonitorCallback,
     // pvac::ClientChanel::PutCallback
     virtual void putBuild(const epics::pvData::StructureConstPtr& build, pvac::ClientChannel::PutCallback::Args& args) OVERRIDE FINAL;
     virtual void putDone(const pvac::PutEvent& evt) OVERRIDE FINAL;
+    struct AfterPut : public epicsThreadRunable {
+        std::tr1::weak_ptr<pvaLinkChannel> lc;
+        virtual ~AfterPut() {}
+        virtual void run() OVERRIDE FINAL;
+    };
+    std::tr1::shared_ptr<AfterPut> AP;
 private:
     virtual void run() OVERRIDE FINAL;
     void run_dbProcess(size_t idx); // idx is index in scan_records
@@ -198,6 +206,7 @@ struct pvaLink : public pvaLinkConfig
     static size_t num_instances;
 
     bool alive; // attempt to catch some use after free
+    dbfType type;
 
     DBLINK * plink; // may be NULL
 

--- a/pdbApp/pvalink.h
+++ b/pdbApp/pvalink.h
@@ -150,6 +150,7 @@ struct pvaLinkChannel : public pvac::ClientChannel::MonitorCallback,
     size_t num_disconnect, num_type_change;
     bool connected;
     bool connected_latched; // connection status at the run()
+    bool put_in_progress;
     bool isatomic;
     bool queued; // added to WorkQueue
     bool debug; // set if any jlink::debug is set

--- a/pdbApp/pvalink_jlif.cpp
+++ b/pdbApp/pvalink_jlif.cpp
@@ -271,7 +271,7 @@ void pva_report(const jlink *rpjlink, int lvl, int indent)
             Guard G(pval->lchan->lock);
 
             printf(" conn=%c", pval->lchan->connected ? 'T' : 'F');
-            if(pval->lchan->op_put.valid()) {
+            if(pval->lchan->put_in_progress) {
                 printf(" Put");
             }
 

--- a/pdbApp/pvalink_link.cpp
+++ b/pdbApp/pvalink_link.cpp
@@ -7,6 +7,7 @@ namespace pvalink {
 
 pvaLink::pvaLink()
     :alive(true)
+    ,type((dbfType)-1)
     ,plink(0)
     ,used_scratch(false)
     ,used_queue(false)

--- a/pdbApp/pvalink_lset.cpp
+++ b/pdbApp/pvalink_lset.cpp
@@ -457,7 +457,7 @@ long pvaPutValueX(DBLINK *plink, short dbrType,
 
         if(!self->defer) self->lchan->put();
 
-        DEBUG(self, <<plink->precord->name<<" "<<CURRENT_FUNCTION<<" "<<self->channelName<<" "<<self->lchan->op_put.valid());
+        DEBUG(self, <<plink->precord->name<<" "<<CURRENT_FUNCTION<<" "<<self->channelName<<" "<<self->lchan->put_in_progress);
         return 0;
     }CATCH()
     return -1;
@@ -487,7 +487,7 @@ void pvaScanForward(DBLINK *plink)
         // FWD_LINK is never deferred, and always results in a Put
         self->lchan->put(true);
 
-        DEBUG(self, <<plink->precord->name<<" "<<CURRENT_FUNCTION<<" "<<self->channelName<<" "<<self->lchan->op_put.valid());
+        DEBUG(self, <<plink->precord->name<<" "<<CURRENT_FUNCTION<<" "<<self->channelName<<" "<<self->lchan->put_in_progress);
     }CATCH()
 }
 

--- a/pdbApp/pvalink_lset.cpp
+++ b/pdbApp/pvalink_lset.cpp
@@ -20,10 +20,24 @@ using namespace pvalink;
 
 #define CHECK_VALID() if(!self->valid()) { DEBUG(self, <<CURRENT_FUNCTION<<" "<<self->channelName<<" !valid"); return -1;}
 
+static
+dbfType getLinkType(DBLINK *plink)
+{
+    dbCommon *prec = plink->precord;
+    pdbRecordIterator iter(prec);
+
+    for(long status = dbFirstField(&iter.ent, 0); !status; status = dbNextField(&iter.ent, 0)) {
+        if(iter.ent.pfield==plink)
+            return iter.ent.pflddes->field_type;
+    }
+    throw std::logic_error("DBLINK* corrupt");
+}
+
 void pvaOpenLink(DBLINK *plink)
 {
     try {
         pvaLink* self((pvaLink*)plink->value.json.jlink);
+        self->type = getLinkType(plink);
 
         // workaround for Base not propagating info(base:lsetDebug to us
         {
@@ -70,6 +84,7 @@ void pvaOpenLink(DBLINK *plink)
                 // open new channel
 
                 chan.reset(new pvaLinkChannel(key, pvRequest));
+                chan->AP->lc = chan;
                 pvaGlobal->channels.insert(std::make_pair(key, chan));
                 doOpen = true;
             }
@@ -397,8 +412,8 @@ pvd::ScalarType DBR2PVD(short dbr)
     throw std::invalid_argument("Unsupported DBR code");
 }
 
-long pvaPutValue(DBLINK *plink, short dbrType,
-        const void *pbuffer, long nRequest)
+long pvaPutValueX(DBLINK *plink, short dbrType,
+        const void *pbuffer, long nRequest, bool wait)
 {
     TRY {
         (void)self;
@@ -437,12 +452,27 @@ long pvaPutValue(DBLINK *plink, short dbrType,
 
         self->used_scratch = true;
 
+        if(wait)
+            self->lchan->after_put.insert(plink->precord);
+
         if(!self->defer) self->lchan->put();
 
         DEBUG(self, <<plink->precord->name<<" "<<CURRENT_FUNCTION<<" "<<self->channelName<<" "<<self->lchan->op_put.valid());
         return 0;
     }CATCH()
     return -1;
+}
+
+long pvaPutValue(DBLINK *plink, short dbrType,
+        const void *pbuffer, long nRequest)
+{
+    return pvaPutValueX(plink, dbrType, pbuffer, nRequest, false);
+}
+
+long pvaPutValueAsync(DBLINK *plink, short dbrType,
+        const void *pbuffer, long nRequest)
+{
+    return pvaPutValueX(plink, dbrType, pbuffer, nRequest, true);
 }
 
 void pvaScanForward(DBLINK *plink)
@@ -485,7 +515,7 @@ lset pva_lset = {
     &pvaGetAlarm,
     &pvaGetTimeStamp,
     &pvaPutValue,
-    NULL,
+    &pvaPutValueAsync,
     &pvaScanForward
     //&pvaReportLink,
 };

--- a/testApp/testpvalink.cpp
+++ b/testApp/testpvalink.cpp
@@ -61,6 +61,33 @@ void testPut()
     testdbGetFieldEqual("src:o2.VAL", DBF_INT64, 14LL);
 }
 
+void testPutAsync()
+{
+#ifdef USE_MULTILOCK
+    testDiag("==== testPutAsync ====");
+
+    int64outRecord *trig = (int64outRecord*)testdbRecordPtr("async:trig");
+
+    while(!dbIsLinkConnected(&trig->out))
+        testqsrvWaitForLinkEvent(&trig->out);
+
+    testMonitor* done = testMonitorCreate("async:after", DBE_VALUE, 0);
+
+    testdbPutFieldOk("async:trig.PROC", DBF_LONG, 1);
+    testMonitorWait(done);
+
+    testdbGetFieldEqual("async:trig",  DBF_LONG, 1);
+    testdbGetFieldEqual("async:slow",  DBF_LONG, 1); // pushed from async:trig
+    testdbGetFieldEqual("async:slow2", DBF_LONG, 2);
+    testdbGetFieldEqual("async:after", DBF_LONG, 3);
+
+    testMonitorDestroy(done);
+
+#else
+    testSkip(5, "Not USE_MULTILOCK");
+#endif
+}
+
 } // namespace
 
 extern "C"
@@ -68,7 +95,7 @@ void pvaLinkTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 MAIN(testpvalink)
 {
-    testPlan(15);
+    testPlan(20);
 
     // Disable PVA client provider, use local/QSRV provider
     pvaLinkIsolate = 1;
@@ -83,6 +110,7 @@ MAIN(testpvalink)
         IOC.init();
         testGet();
         testPut();
+        testPutAsync();
         testqsrvShutdownOk();
         IOC.shutdown();
         testqsrvCleanup();

--- a/testApp/testpvalink.db
+++ b/testApp/testpvalink.db
@@ -19,3 +19,32 @@ record(int64in, "target:i2") {
 record(int64out, "src:o2") {
     field(OUT, {"pva":"target:i2"})
 }
+
+# used by testPutAsync()
+record(calc, "async:seq") {
+    field(CALC, "VAL+1")
+    field(VAL , "0")
+}
+
+record(longout, "async:trig") {
+    field(OMSL, "closed_loop")
+    field(DOL , "async:seq PP")
+    field(DTYP, "Async Soft Channel")
+    field(OUT , { "pva":{"pv":"async:slow.A", "proc":true} })
+    field(FLNK, "async:after")
+}
+
+record(calcout, "async:slow") {
+    field(ODLY, "1")
+    field(CALC, "A")
+    field(FLNK, "async:slow2")
+}
+
+record(longin, "async:slow2") {
+    field(INP , "async:seq PP")
+}
+
+record(longin, "async:after") {
+    field(INP , "async:seq PP")
+    field(MDEL, "-1")
+}


### PR DESCRIPTION
Add asynchronous output link support.  When triggered, re-process record(s) after put completes