### PR TITLE
Structure map type

### DIFF
--- a/documentation/qsrvpage.dox
+++ b/documentation/qsrvpage.dox
@@ -108,6 +108,7 @@ record(...) {
 @li "any"
 @li "meta"
 @li "proc"
+@li "structure"
 
 The "scalar" mapping places an NTScalar or NTScalarArray as a sub-structure.
 
@@ -123,6 +124,9 @@ placed in the top-level structure.
 
 The "proc" mapping uses neither "value" nor meta-data.
 Instead the target record is processed during a put.
+
+The "structure" mapping allows an "+id" to be attached without a "+channel".
+So none of "+channel", "+trigger", nor "+putorder" are meaningful for a "structure" mapping.
 
 @subsubsection qsrv_group_map_trig Field Update Triggers
 

--- a/documentation/release_notes.dox
+++ b/documentation/release_notes.dox
@@ -5,6 +5,9 @@
 Release 1.3.2 (UNRELEASED)
 ==========================
 
+- Additions
+ - Add new "structure" to @ref qsrv_group_map_types
+
 Release 1.3.1 (June 2021)
 =========================
 

--- a/iocBoot/iocimagedemo/ntenum.db
+++ b/iocBoot/iocimagedemo/ntenum.db
@@ -1,0 +1,26 @@
+# Example of constructing an NTEnum with a longer choices list.
+
+record(longout, "$(P):ENUM:INDEX") {
+    field(VAL, "1")
+    field(PINI, "YES")
+    info(Q:group, {
+        "$(P):ENUM":{
+            +id:"epics:nt/NTEnum:1.0",
+            "value":{+type:"structure", +id:"enum_t"},
+            "value.index":{+type:"plain", +channel:"VAL"},
+            "":{+type:"meta", +channel:"VAL"}
+        }
+    })
+}
+
+record(aai, "$(P):ENUM:CHOICES") {
+    field(FTVL, "STRING")
+    field(NELM, "64")
+    field(INP , {const:["ZERO", "ONE"]})
+    info(Q:group, {
+        "$(P):ENUM":{
+            +id:"epics:nt/NTEnum:1.0",
+            "value.choices":{+type:"plain", +channel:"VAL"}
+        }
+    })
+}

--- a/iocBoot/iocimagedemo/st.cmd
+++ b/iocBoot/iocimagedemo/st.cmd
@@ -2,5 +2,6 @@
 
 dbLoadRecords("image.db","N=TST:image1")
 dbLoadRecords("table.db","N=TST:table1")
+dbLoadRecords("ntenum.db","P=TST:enum1")
 
 iocInit()

--- a/pdbApp/pvif.cpp
+++ b/pdbApp/pvif.cpp
@@ -777,6 +777,9 @@ short PVD2DBR(pvd::ScalarType pvt)
 epics::pvData::FieldConstPtr
 ScalarBuilder::dtype()
 {
+    if(!channel)
+        throw std::runtime_error("+type:\"scalar\" requires +channel:");
+
     short dbr = dbChannelFinalFieldType(channel);
     const long maxelem = dbChannelFinalElements(channel);
     const pvd::ScalarType pvt = DBR2PVD(dbr);
@@ -955,6 +958,9 @@ struct PlainBuilder : public PVIFBuilder
 
     // fetch the structure description
     virtual epics::pvData::FieldConstPtr dtype() OVERRIDE FINAL {
+        if(!channel)
+            throw std::runtime_error("+type:\"plain\" requires +channel:");
+
         const short dbr = dbChannelFinalFieldType(channel);
         const long maxelem = dbChannelFinalElements(channel);
         const pvd::ScalarType pvt = DBR2PVD(dbr);


### PR DESCRIPTION
Add mapping `+type:"structure"` to allow an `+id` to be assigned to structure nodes which don't have a `+channel`.  Also add example of building NTEnum with arbitrarily long choices array.