### PR TITLE
Cleanup clang compiler warnings

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ cache:
 
 install:
 # for the sequencer
-  - cinst re2c
+  - choco install re2c
   - cmd: git submodule update --init --recursive
 
 #---------------------------------#

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -5,7 +5,7 @@
 
 # Workflow name
 
-name: Base
+name: pva2pva
 
 # Trigger on pushes and PRs to any branch
 on:
@@ -13,10 +13,12 @@ on:
     paths-ignore:
       - .appveyor.yml
   pull_request:
+  workflow_dispatch:
 
 env:
     SETUP_PATH: .ci-local:.ci
     EPICS_TEST_IMPRECISE_TIMING: YES
+    EPICS_TEST_TIMEOUT: 300 # 5 min
 
 jobs:
   native:
@@ -24,11 +26,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     # Set environment variables from matrix parameters
     env:
+      # NB: PVA modules build against both BASE 7.0 and 3.15
       BASE: ${{ matrix.base }}
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
-      WINE: ${{ matrix.wine }}
-      RTEMS: ${{ matrix.rtems }}
+      CI_CROSS_TARGETS: ${{ matrix.cross }}
       EXTRA: ${{ matrix.extra }}
       TEST: ${{ matrix.test }}
     strategy:
@@ -36,89 +38,171 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
-          - os: ubuntu-20.04
+          - name: "7.0 Ub gcc c++20 Werror"
+            base: "7.0"
+            os: ubuntu-latest
             cmp: gcc
             configuration: default
-            base: "7.0"
-            wine: "64"
-            name: "7.0 Ub-20 gcc-9 + MinGW"
+            # Turn all warnings into errors,
+            # except for those we could not fix (yet).
+            # Remove respective -Wno-error=... flag once it is fixed.
+            extra: "CMD_CXXFLAGS=-std=c++20
+                    CMD_CPPFLAGS='-fdiagnostics-color
+                                  -fstack-protector-strong
+                                  -Wformat
+                                  -Werror
+                                  -Werror=format-security
+                                  -Wno-error=deprecated-declarations
+                                  -Wno-error=stringop-truncation
+                                  -Wno-error=restrict
+                                  -Wno-error=sizeof-pointer-memaccess
+                                  -Wno-error=nonnull
+                                  -Wno-error=dangling-pointer
+                                  -Wno-error=format-overflow
+                                  -Wno-error=stringop-overread
+                                  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
+                    CMD_LDFLAGS=-Wl,-z,relro"
 
-          - os: ubuntu-20.04
+          - name: "7.0 Ub gcc C++11, static"
+            base: "7.0"
+            os: ubuntu-latest
             cmp: gcc
             configuration: static
-            base: "7.0"
-            wine: "64"
-            name: "7.0 Ub-20 gcc-9 + MinGW, static"
+            extra: "CMD_CXXFLAGS=-std=c++11"
 
-          - os: ubuntu-20.04
+          - name: "7.0 Ub gcc u-char"
+            base: "7.0"
+            os: ubuntu-latest
             cmp: gcc
+            configuration: static
+            extra: "CMD_CFLAGS=-funsigned-char CMD_CXXFLAGS=-funsigned-char"
+
+          - name: "7.0 Ub clang"
+            base: "7.0"
+            os: ubuntu-latest
+            cmp: clang
             configuration: default
+
+          - name: "7.0 Ub clang C++11"
+            base: "7.0"
+            os: ubuntu-latest
+            cmp: clang
+            configuration: default
+            extra: "CMD_CXXFLAGS=-std=c++11"
+
+          - name: "7.0 MacOS clang"
+            base: "7.0"
+            os: macos-latest
+            cmp: clang
+            configuration: default
+
+          # Cross builds
+
+          - name: "3.15 Ub-22 gcc + MinGW"
             base: "3.15"
-            wine: "64"
-            name: "3.15 Ub-20 gcc-9 + MinGW"
+            os: ubuntu-22.04
+            cmp: gcc
+            configuration: default
+            cross: "windows-x64-mingw"
 
-          - os: ubuntu-20.04
+          - name: "7.0 Ub gcc + linux-aarch64"
+            base: "7.0"
+            os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            cross: "linux-aarch64"
+
+          - name: "7.0 Ub gcc + linux-arm gnueabi"
+            base: "7.0"
+            os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            cross: "linux-arm@arm-linux-gnueabi"
+
+          - name: "7.0 Ub gcc + linux-arm gnueabihf"
+            base: "7.0"
+            os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            cross: "linux-arm@arm-linux-gnueabihf"
+
+          - name: "7.0 Ub gcc + MinGW"
+            base: "7.0"
+            os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            cross: "windows-x64-mingw"
+
+          - name: "7.0 Ub gcc + MinGW, static"
+            base: "7.0"
+            os: ubuntu-latest
             cmp: gcc
             configuration: static
-            base: "7.0"
-            extra: "CMD_CXXFLAGS=-std=c++11"
-            name: "7.0 Ub-20 gcc-9 C++11, static"
+            cross: "windows-x64-mingw"
 
-          - os: ubuntu-20.04
-            cmp: clang
-            configuration: default
+          - name: "7.0 Ub-22 gcc + RT-4.9 pc386"
             base: "7.0"
-            extra: "CMD_CXXFLAGS=-std=c++11"
-            name: "7.0 Ub-20 clang-10 C++11"
-
-          - os: ubuntu-20.04
+            os: ubuntu-22.04
             cmp: gcc
             configuration: default
-            base: "7.0"
-            rtems: "4.10"
-            name: "7.0 Ub-20 gcc-9 + RT-4.10"
+            cross: "RTEMS-pc386-qemu@4.9"
 
-          - os: ubuntu-20.04
+          - name: "7.0 Ub-22 gcc + RT-4.10 pc386"
+            base: "7.0"
+            os: ubuntu-22.04
             cmp: gcc
             configuration: default
-            base: "7.0"
-            rtems: "4.9"
-            name: "7.0 Ub-20 gcc-9 + RT-4.9"
+            cross: "RTEMS-pc386-qemu@4.10"
+            test: NO
 
-          - os: ubuntu-20.04
-            cmp: clang
+          - name: "7.0 Ub-22 gcc + RT-5.1 pc686"
+            base: "7.0"
+            os: ubuntu-22.04
+            cmp: gcc
             configuration: default
-            base: "7.0"
-            name: "7.0 Ub-20 clang-10"
+            cross: "RTEMS-pc686-qemu@5"
 
-          - os: macos-latest
-            cmp: clang
+          - name: "7.0 Ub-22 gcc + RT-5.1 beatnik,zynq_a9,uC5282"
+            base: "7.0"
+            os: ubuntu-22.04
+            cmp: gcc
             configuration: default
-            base: "7.0"
-            name: "7.0 MacOS clang-12"
+            cross: "RTEMS-beatnik@5:RTEMS-xilinx_zynq_a9_qemu@5:RTEMS-uC5282@5"
+            test: NO
 
-          - os: windows-2019
-            cmp: vs2019
+          # Windows builds
+
+          - name: "7.0 Win-22 MSC-22"
+            base: "7.0"
+            os: windows-2022
+            cmp: vs2022
             configuration: default
-            base: "7.0"
-            name: "7.0 Win2019 MSC-19"
 
-          - os: windows-2019
-            cmp: vs2019
+          - name: "7.0 Win-22 MSC-22 static"
+            base: "7.0"
+            os: windows-2022
+            cmp: vs2022
             configuration: static
-            base: "7.0"
-            name: "7.0 Win2019 MSC-19, static"
 
-          - os: windows-2019
-            cmp: gcc
-            configuration: static
+          - name: "7.0 Win-22 MSC-22 debug"
             base: "7.0"
-            name: "7.0 Win2019 mingw, static"
+            os: windows-2022
+            cmp: vs2022
+            configuration: debug
+            extra: "CMD_CXXFLAGS=-analyze"
+
+          - name: "7.0 Win-22 MinGW"
+            base: "7.0"
+            os: windows-2022
+            cmp: gcc
+            configuration: default
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Automatic core dumper analysis
+      uses: mdavidsaver/ci-core-dumper@master
     - name: "apt-get install"
       run: |
         sudo apt-get update
@@ -129,15 +213,17 @@ jobs:
     - name: Build main module
       run: python .ci/cue.py build
     - name: Run main module tests
-      run: python .ci/cue.py test
+      run: python .ci/cue.py -T 60M test
     - name: Upload tapfiles Artifact
+      if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
         name: tapfiles ${{ matrix.name }}
         path: '**/O.*/*.tap'
         if-no-files-found: ignore
     - name: Collect and show test results
-      run: python .ci/cue.py test-results
+      if: ${{ always() }}
+      run: python .ci/cue.py -T 5M test-results
 
   docker:
     name: ${{ matrix.name }}
@@ -149,8 +235,6 @@ jobs:
       BASE: ${{ matrix.base }}
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
-      WINE: ${{ matrix.wine }}
-      RTEMS: ${{ matrix.rtems }}
       EXTRA: ${{ matrix.extra }}
       TEST: ${{ matrix.test }}
     strategy:
@@ -158,59 +242,61 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
-          - name: Linux centos 7
-            image: centos:7
+          - name: "7.0 CentOS-8 gcc"
+            base: "7.0"
+            image: centos:8
             cmp: gcc
             configuration: default
-            base: "7.0"
 
-          - name: Linux fedora latest
+          - name: "7.0 Rocky-9 gcc"
+            base: "7.0"
+            image: rockylinux:9
+            cmp: gcc
+            configuration: default
+
+          - name: "7.0 Fedora-33 gcc"
+            base: "7.0"
+            image: fedora:33
+            cmp: gcc
+            configuration: default
+
+          - name: "7.0 Fedora gcc"
+            base: "7.0"
             image: fedora:latest
             cmp: gcc
             configuration: default
-            base: "7.0"
 
     steps:
-    - name: "Build newer Git"
-      # actions/checkout@v2 wants git >=2.18
-      # centos:7 has 1.8
-      if: matrix.image=='centos:7'
+    - name: "Fix repo URLs on CentOS-8"
+      # centos:8 is frozen, repos are in the vault
+      if: matrix.image=='centos:8'
       run: |
-        yum -y install curl make gcc curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker
-        curl https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.29.0.tar.gz | tar -xz
-        cd git-*
-        make -j2 prefix=/usr/local all
-        make prefix=/usr/local install
-        cd ..
-        rm -rf git-*
-        type -a git
-        git --version
+        sed -i -e "s|mirrorlist=|#mirrorlist=|" \
+        -e "s|#baseurl=http://mirror|baseurl=http://vault|" \
+        /etc/yum.repos.d/CentOS-Linux-{BaseOS,AppStream,Extras,Plus}.repo
     - name: "Redhat setup"
       run: |
-        dnfyum() {
-            dnf -y "$@" || yum -y "$@"
-            return $?
-        }
-        dnfyum install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel libevent-devel net-tools
-        git --version || dnfyum install git
-        # rather than just bite the bullet and link python3 -> python,
-        # people would rather just break all existing scripts...
-        [ -e /usr/bin/python ] || ln -sf /usr/bin/python3 /usr/bin/python
-        python --version
-    - uses: actions/checkout@v2
+        dnf -y install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple
+        git --version || dnf -y install git
+        python3 --version
+    - uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Automatic core dumper analysis
+      uses: mdavidsaver/ci-core-dumper@master
     - name: Prepare and compile dependencies
-      run: python .ci/cue.py prepare
+      run: python3 .ci/cue.py prepare
     - name: Build main module
-      run: python .ci/cue.py build
+      run: python3 .ci/cue.py build
     - name: Run main module tests
-      run: python .ci/cue.py test
+      run: python3 .ci/cue.py -T 20M test
     - name: Upload tapfiles Artifact
+      if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
         name: tapfiles ${{ matrix.name }}
         path: '**/O.*/*.tap'
         if-no-files-found: ignore
     - name: Collect and show test results
-      run: python .ci/cue.py test-results
+      if: ${{ always() }}
+      run: python3 .ci/cue.py -T 5M test-results

--- a/common/utilities.h
+++ b/common/utilities.h
@@ -66,8 +66,10 @@ struct TestChannelRequester : public epics::pvAccess::ChannelRequester
     epics::pvAccess::Channel::ConnectionState laststate;
     TestChannelRequester();
     virtual ~TestChannelRequester();
-    virtual void channelCreated(const epics::pvData::Status& status, epics::pvAccess::Channel::shared_pointer const & channel);
-    virtual void channelStateChange(epics::pvAccess::Channel::shared_pointer const & channel, epics::pvAccess::Channel::ConnectionState connectionState);
+    virtual void channelCreated(const epics::pvData::Status& status,
+            epics::pvAccess::Channel::shared_pointer const & channel) OVERRIDE FINAL;
+    virtual void channelStateChange(epics::pvAccess::Channel::shared_pointer const & channel,
+            epics::pvAccess::Channel::ConnectionState connectionState) OVERRIDE FINAL;
 
     bool waitForConnect();
 };
@@ -86,7 +88,7 @@ struct TestChannelFieldRequester : public epics::pvAccess::GetFieldRequester
 
     virtual void getDone(
            const epics::pvData::Status& status,
-           epics::pvData::FieldConstPtr const & field)
+           epics::pvData::FieldConstPtr const & field) OVERRIDE FINAL
     {
         this->status = status;
         fielddesc = field;
@@ -112,13 +114,15 @@ struct TestChannelGetRequester : public epics::pvAccess::ChannelGetRequester
     virtual void channelGetConnect(
             const epics::pvData::Status& status,
             epics::pvAccess::ChannelGet::shared_pointer const & channelGet,
-            epics::pvData::Structure::const_shared_pointer const & structure);
+            epics::pvData::Structure::const_shared_pointer const & structure)
+            OVERRIDE FINAL;
 
     virtual void getDone(
             const epics::pvData::Status& status,
             epics::pvAccess::ChannelGet::shared_pointer const & channelGet,
             epics::pvData::PVStructure::shared_pointer const & pvStructure,
-            epics::pvData::BitSet::shared_pointer const & bitSet);
+            epics::pvData::BitSet::shared_pointer const & bitSet)
+            OVERRIDE FINAL;
 };
 
 struct TestChannelPutRequester : public epics::pvAccess::ChannelPutRequester
@@ -139,17 +143,20 @@ struct TestChannelPutRequester : public epics::pvAccess::ChannelPutRequester
     virtual void channelPutConnect(
             const epics::pvData::Status& status,
             epics::pvAccess::ChannelPut::shared_pointer const & channelPut,
-            epics::pvData::Structure::const_shared_pointer const & structure);
+            epics::pvData::Structure::const_shared_pointer const & structure)
+            OVERRIDE FINAL;
 
     virtual void putDone(
             const epics::pvData::Status& status,
-            epics::pvAccess::ChannelPut::shared_pointer const & channelPut);
+            epics::pvAccess::ChannelPut::shared_pointer const & channelPut)
+            OVERRIDE FINAL;
 
     virtual void getDone(
             const epics::pvData::Status& status,
             epics::pvAccess::ChannelPut::shared_pointer const & channelPut,
             epics::pvData::PVStructure::shared_pointer const & pvStructure,
-            epics::pvData::BitSet::shared_pointer const & bitSet);
+            epics::pvData::BitSet::shared_pointer const & bitSet)
+            OVERRIDE FINAL;
 };
 
 struct TestChannelMonitorRequester : public epics::pvData::MonitorRequester
@@ -171,9 +178,10 @@ struct TestChannelMonitorRequester : public epics::pvData::MonitorRequester
 
     virtual void monitorConnect(epics::pvData::Status const & status,
                                 epics::pvData::MonitorPtr const & monitor,
-                                epics::pvData::StructureConstPtr const & structure);
-    virtual void monitorEvent(epics::pvData::MonitorPtr const & monitor);
-    virtual void unlisten(epics::pvData::MonitorPtr const & monitor);
+                                epics::pvData::StructureConstPtr const & structure)
+                                OVERRIDE FINAL;
+    virtual void monitorEvent(epics::pvData::MonitorPtr const & monitor) OVERRIDE FINAL;
+    virtual void unlisten(epics::pvData::MonitorPtr const & monitor) OVERRIDE FINAL;
 
     bool waitForConnect();
     bool waitForEvent();
@@ -195,14 +203,18 @@ struct TestPVChannel : public BaseChannel
                   const std::tr1::shared_ptr<epics::pvAccess::ChannelRequester>& req);
     virtual ~TestPVChannel();
 
-    virtual std::string getRemoteAddress() { return "localhost:1234"; }
-    virtual ConnectionState getConnectionState();
+    virtual std::string getRemoteAddress() OVERRIDE FINAL
+    { return "localhost:1234"; }
+    virtual ConnectionState getConnectionState() OVERRIDE FINAL;
 
-    virtual void getField(epics::pvAccess::GetFieldRequester::shared_pointer const & requester,std::string const & subField);
+    virtual void getField(
+            epics::pvAccess::GetFieldRequester::shared_pointer const & requester,
+            std::string const & subField) OVERRIDE FINAL;
 
     virtual epics::pvData::Monitor::shared_pointer createMonitor(
             epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
-            epics::pvData::PVStructure::shared_pointer const & pvRequest);
+            epics::pvData::PVStructure::shared_pointer const & pvRequest)
+            OVERRIDE FINAL;
 };
 
 struct TestPVMonitor : public epics::pvData::Monitor

--- a/p2pApp/gwmain.cpp
+++ b/p2pApp/gwmain.cpp
@@ -280,7 +280,7 @@ int main(int argc, char *argv[])
             lvl = pva::logLevelDebug;
         else if(arg.debug==3)
             lvl = pva::logLevelTrace;
-        else if(arg.debug>=4)
+        else // arg.debug>=4
             lvl = pva::logLevelAll;
         SET_LOG_LEVEL(lvl);
 

--- a/pdbApp/softMain.cpp
+++ b/pdbApp/softMain.cpp
@@ -261,7 +261,10 @@ int main(int argc, char *argv[])
 
         } else {
             if (loadedDb || ranScript) {
-                epicsThreadExitMain();
+                // Non-interactive IOC, spin forever
+                while(true) {
+                    epicsThreadSleep(1000.0);
+                }
 
             } else {
                 usage(argv[0], dbd_file);

--- a/testApp/Makefile
+++ b/testApp/Makefile
@@ -24,7 +24,6 @@ PROD_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 TESTPROD_HOST += testweak
 testweak_SRCS += testweak.cpp
-testweak_LIBS += Com
 TESTS += testweak
 
 TESTPROD_HOST += testtest
@@ -57,14 +56,12 @@ testpvalink_LIBS += qsrv
 
 TESTPROD_HOST += testgroupconfig
 testgroupconfig_SRCS += testgroupconfig
-testgroupconfig_LIBS += qsrv pvAccess pvData
-testgroupconfig_LIBS += $(EPICS_BASE_IOC_LIBS)
+testgroupconfig_LIBS += qsrv
 TESTS += testgroupconfig
 
 TESTPROD_HOST += testdbf_copy
 testdbf_copy_SRCS += testdbf_copy
-testdbf_copy_LIBS += qsrv pvAccess pvData
-testdbf_copy_LIBS += $(EPICS_BASE_IOC_LIBS)
+testdbf_copy_LIBS += qsrv
 TESTS += testdbf_copy
 endif
 

--- a/testApp/check_consist.cpp
+++ b/testApp/check_consist.cpp
@@ -7,11 +7,14 @@ namespace pvd = epics::pvData;
 namespace pva = epics::pvAccess;
 
 namespace {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 struct Destroyer {
     pvd::Destroyable::shared_pointer D;
     Destroyer(const pvd::Destroyable::shared_pointer& d) : D(d) {}
     ~Destroyer() { if(D) D->destroy(); }
 };
+#pragma GCC diagnostic pop
 
 struct Releaser {
     pva::Monitor::shared_pointer& mon;


### PR DESCRIPTION
After these changes there's only one build warning left from pva2pva builds with Clang 15.0 on macOS, a deprecation warning for `epicsThreadExitMain()` which I deliberately left in. I removed the other deprecation warnings because they are in test files that apparently check the deprecated API.

I had to update the .ci module to various targets to build, but I didn't get around to removing the CentOS-7 build so that still dies.