### PR TITLE
modifications to use custom_alarm_msg.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,19 +17,7 @@ install:
   - choco install re2c -y
   - cmd: git submodule update --init --recursive
   - cmd: pip install setuptools
- # .ci/cue.py 존재 확인, 없으면 강제 fetch & 오류 메시지
-  - cmd: |
-      if not exist .ci\cue.py (
-        echo ERROR: .ci\cue.py not found! Please check that .ci submodule is correctly initialized.
-        git submodule deinit -f .ci
-        git submodule update --init --recursive
-        if not exist .ci\cue.py (
-          echo FATAL: .ci/cue.py is STILL missing after submodule update! Failing build.
-          exit /b 2
-        )
-      ) else (
-        echo Found .ci\cue.py
-      )
+
 
 #---------------------------------#
 #       repository cloning        #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,7 @@ install:
   - ps: Set-ExecutionPolicy Bypass -Scope Process -Force
   - ps: '[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072'
   - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+  - choco install strawberryperl -y
   - choco install re2c -y
   - cmd: git submodule update --init --recursive
   - cmd: pip install setuptools

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,7 @@ install:
   - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
   - choco install re2c -y
   - cmd: git submodule update --init --recursive
+  - cmd: pip install setuptools
 
 #---------------------------------#
 #       repository cloning        #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,13 @@ cache:
 #---------------------------------#
 
 install:
-# for the sequencer
-  - choco install re2c
+  - choco install python --version=3.10.9 -y
+  - refreshenv
+  - python -m ensurepip --upgrade
+  - python -m pip install --upgrade pip setuptools
+
+  # for the sequencer
+  - choco install re2c -y
   - cmd: git submodule update --init --recursive
 
 #---------------------------------#

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,10 +14,22 @@ install:
   - ps: Set-ExecutionPolicy Bypass -Scope Process -Force
   - ps: '[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072'
   - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-  - choco install strawberryperl -y --force
   - choco install re2c -y
   - cmd: git submodule update --init --recursive
   - cmd: pip install setuptools
+ # .ci/cue.py 존재 확인, 없으면 강제 fetch & 오류 메시지
+  - cmd: |
+      if not exist .ci\cue.py (
+        echo ERROR: .ci\cue.py not found! Please check that .ci submodule is correctly initialized.
+        git submodule deinit -f .ci
+        git submodule update --init --recursive
+        if not exist .ci\cue.py (
+          echo FATAL: .ci/cue.py is STILL missing after submodule update! Failing build.
+          exit /b 2
+        )
+      ) else (
+        echo Found .ci\cue.py
+      )
 
 #---------------------------------#
 #       repository cloning        #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,14 +11,15 @@ cache:
 #---------------------------------#
 
 install:
-  - choco install python --version=3.10.9 -y
+
+  - powershell -Command "Invoke-WebRequest https://www.python.org/ftp/python/3.10.9/python-3.10.9-amd64.exe -OutFile python-install.exe"
+  - start /wait python-install.exe /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
   - refreshenv
-  - python -m ensurepip --upgrade
   - python -m pip install --upgrade pip setuptools
 
-  # for the sequencer
+  # For the sequencer
   - choco install re2c -y
-  - cmd: git submodule update --init --recursive
+  - git submodule update --init --recursive
 
 #---------------------------------#
 #       repository cloning        #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ install:
   - ps: Set-ExecutionPolicy Bypass -Scope Process -Force
   - ps: '[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072'
   - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-  - choco install strawberryperl -y
+  - choco install strawberryperl -y --force
   - choco install re2c -y
   - cmd: git submodule update --init --recursive
   - cmd: pip install setuptools

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ cache:
 
 install:
   - ps: Set-ExecutionPolicy Bypass -Scope Process -Force
-  - ps: [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+  - ps: '[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072'
   - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
   - choco install re2c -y
   - cmd: git submodule update --init --recursive

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,10 @@ cache:
 #---------------------------------#
 
 install:
-# for the sequencer
-  - cinst re2c
+  - ps: Set-ExecutionPolicy Bypass -Scope Process -Force
+  - ps: [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+  - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+  - choco install re2c -y
   - cmd: git submodule update --init --recursive
 
 #---------------------------------#

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,13 +11,9 @@ cache:
 #---------------------------------#
 
 install:
-  - ps: Set-ExecutionPolicy Bypass -Scope Process -Force
-  - ps: '[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072'
-  - ps: iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-  - choco install re2c -y
+# for the sequencer
+  - choco install re2c
   - cmd: git submodule update --init --recursive
-  - cmd: pip install setuptools
-
 
 #---------------------------------#
 #       repository cloning        #

--- a/pdbApp/pvif.cpp
+++ b/pdbApp/pvif.cpp
@@ -27,6 +27,13 @@
 
 #include <epicsExport.h>
 
+#include <fstream>
+#include <string>
+
+#ifdef HAVE_UTAG
+#define ISIS_CUSTOM_ALARM_MSG
+#endif
+
 #ifdef EPICS_VERSION_INT
 #  if EPICS_VERSION_INT>=VERSION_INT(3,16,1,0)
 #    define USE_INT64
@@ -344,18 +351,32 @@ void attachAll(PVX& pvm, const pvd::PVStructurePtr& pv)
 }
 
 template<typename Meta>
+#ifdef ISIS_CUSTOM_ALARM_MSG
+void mapStatus(const Meta& meta, pvd::PVInt* status, pvd::PVString* message, dbChannel *chan)
+#else
 void mapStatus(const Meta& meta, pvd::PVInt* status, pvd::PVString* message)
+#endif
 {
+#ifdef ISIS_CUSTOM_ALARM_MSG
+    pdbRecordIterator info(chan);
+    const char *userMsg = info.info("q:alarm:user_message");
+#endif
 #ifdef HAVE_UTAG
     if(meta.amsg[0]!='\0') {
         message->put(meta.amsg);
     } else
 #endif
+#ifdef ISIS_CUSTOM_ALARM_MSG
+    if(userMsg != NULL && meta.status > NO_ALARM) {
+        message->put(userMsg);
+    } else 
+#endif    
+    {
     if(meta.status<ALARM_NSTATUS)
         message->put(epicsAlarmConditionStrings[meta.status]);
     else
         message->put("???");
-
+    }
     // Arbitrary mapping from DB status codes
     unsigned out;
     switch(meta.status) {
@@ -425,7 +446,11 @@ void putTime(const pvTimeAlarm& pv, unsigned dbe, db_field_log *pfl)
 
     putMetaImpl(pv, meta);
     if(dbe&DBE_ALARM) {
+        #ifdef ISIS_CUSTOM_ALARM_MSG
+        mapStatus(meta, pv.status.get(), pv.message.get(), pv.chan);
+        #else
         mapStatus(meta, pv.status.get(), pv.message.get());
+        #endif
         pv.severity->put(meta.severity);
     }
 }
@@ -571,7 +596,11 @@ void putMeta(const pvCommon& pv, unsigned dbe, db_field_log *pfl)
     putMetaImpl(pv, meta);
 #define FMAP(MNAME, FNAME) pv.MNAME->put(meta.FNAME)
     if(dbe&DBE_ALARM) {
+        #ifdef ISIS_CUSTOM_ALARM_MSG
+        mapStatus(meta, pv.status.get(), pv.message.get(), pv.chan);
+        #else
         mapStatus(meta, pv.status.get(), pv.message.get());
+        #endif
         FMAP(severity, severity);
     }
     if(dbe&DBE_PROPERTY) {

--- a/pdbApp/pvif.cpp
+++ b/pdbApp/pvif.cpp
@@ -28,7 +28,7 @@
 #include <epicsExport.h>
 
 #ifdef HAVE_UTAG
-#define ISIS_CUSTOM_ALARM_MSG
+#define CUSTOM_ALARM_MSG
 #endif
 
 #ifdef EPICS_VERSION_INT
@@ -348,22 +348,22 @@ void attachAll(PVX& pvm, const pvd::PVStructurePtr& pv)
 }
 
 template<typename Meta>
-#ifdef ISIS_CUSTOM_ALARM_MSG
+#ifdef CUSTOM_ALARM_MSG
 void mapStatus(const Meta& meta, pvd::PVInt* status, pvd::PVString* message, dbChannel *chan)
 #else
 void mapStatus(const Meta& meta, pvd::PVInt* status, pvd::PVString* message)
 #endif
 {
-#ifdef ISIS_CUSTOM_ALARM_MSG
+#ifdef CUSTOM_ALARM_MSG
     pdbRecordIterator info(chan);
-    const char *userMsg = info.info("q:alarm:user_message");
+    const char *userMsg = info.info("Q:alarm:msg");
 #endif
 #ifdef HAVE_UTAG
     if(meta.amsg[0]!='\0') {
         message->put(meta.amsg);
     } else
 #endif
-#ifdef ISIS_CUSTOM_ALARM_MSG
+#ifdef CUSTOM_ALARM_MSG
     if(userMsg != NULL && meta.status > NO_ALARM) {
         message->put(userMsg);
     } else 
@@ -443,7 +443,7 @@ void putTime(const pvTimeAlarm& pv, unsigned dbe, db_field_log *pfl)
 
     putMetaImpl(pv, meta);
     if(dbe&DBE_ALARM) {
-        #ifdef ISIS_CUSTOM_ALARM_MSG
+        #ifdef CUSTOM_ALARM_MSG
         mapStatus(meta, pv.status.get(), pv.message.get(), pv.chan);
         #else
         mapStatus(meta, pv.status.get(), pv.message.get());
@@ -593,7 +593,7 @@ void putMeta(const pvCommon& pv, unsigned dbe, db_field_log *pfl)
     putMetaImpl(pv, meta);
 #define FMAP(MNAME, FNAME) pv.MNAME->put(meta.FNAME)
     if(dbe&DBE_ALARM) {
-        #ifdef ISIS_CUSTOM_ALARM_MSG
+        #ifdef CUSTOM_ALARM_MSG
         mapStatus(meta, pv.status.get(), pv.message.get(), pv.chan);
         #else
         mapStatus(meta, pv.status.get(), pv.message.get());

--- a/pdbApp/pvif.cpp
+++ b/pdbApp/pvif.cpp
@@ -27,9 +27,6 @@
 
 #include <epicsExport.h>
 
-#include <fstream>
-#include <string>
-
 #ifdef HAVE_UTAG
 #define ISIS_CUSTOM_ALARM_MSG
 #endif

--- a/testApp/test_custom_alarm.db
+++ b/testApp/test_custom_alarm.db
@@ -1,0 +1,10 @@
+record(ai, "custom:ai") {
+    field(DESC, "Custom Analog Input for Alarm Test")
+    field(DTYP, "Soft Channel")
+    field(SCAN, "Passive")
+    field(HIHI, "50.0")
+    field(HIGH, "40.0")
+    field(HHSV, "MAJOR")
+    field(HSV, "MINOR")
+    info(q:alarm:user_message, "Custom Msg Alarm AI!")
+}

--- a/testApp/test_custom_alarm.db
+++ b/testApp/test_custom_alarm.db
@@ -6,5 +6,5 @@ record(ai, "custom:ai") {
     field(HIGH, "40.0")
     field(HHSV, "MAJOR")
     field(HSV, "MINOR")
-    info(q:alarm:user_message, "Custom Msg Alarm AI!")
+    info(Q:alarm:msg, "Custom Msg Alarm AI!")
 }

--- a/testApp/testpvif.cpp
+++ b/testApp/testpvif.cpp
@@ -22,7 +22,7 @@
 
 
 #ifdef HAVE_UTAG
-#define ISIS_CUSTOM_ALARM_MSG
+#define CUSTOM_ALARM_MSG
 #endif
 
 namespace pvd = epics::pvData;
@@ -642,7 +642,7 @@ void testFilters()
     testFieldEqual<pvd::PVShortArray>(root, "dut.value", expected);
 #endif // >= 7.0
 }
-#ifdef ISIS_CUSTOM_ALARM_MSG
+#ifdef CUSTOM_ALARM_MSG
 void testCustomAlarmMessage()
 {
     testDiag("testCustomAlarmMessage");
@@ -696,12 +696,12 @@ void testCustomAlarmMessage()
     testFieldEqual<pvd::PVInt>(root, "custom_ai.alarm.severity", 0);
     testFieldEqual<pvd::PVInt>(root, "custom_ai.alarm.status", 0);
 }
-#endif // ISIS_CUSTOM_ALARM_MSG
+#endif // CUSTOM_ALARM_MSG
 } // namespace
 
 MAIN(testpvif)
 {
-#ifdef ISIS_CUSTOM_ALARM_MSG
+#ifdef CUSTOM_ALARM_MSG
     testPlan(105);
 #else
     testPlan(98);
@@ -714,7 +714,7 @@ MAIN(testpvif)
     testScalar();
     testPlain();
     testFilters();
-#ifdef ISIS_CUSTOM_ALARM_MSG
+#ifdef CUSTOM_ALARM_MSG
     testCustomAlarmMessage();
 #endif
     return testDone();

--- a/testApp/testpvif.cpp
+++ b/testApp/testpvif.cpp
@@ -20,6 +20,11 @@
 #include "pvif.h"
 #include "utilities.h"
 
+
+#ifdef HAVE_UTAG
+#define ISIS_CUSTOM_ALARM_MSG
+#endif
+
 namespace pvd = epics::pvData;
 
 extern "C"
@@ -637,12 +642,70 @@ void testFilters()
     testFieldEqual<pvd::PVShortArray>(root, "dut.value", expected);
 #endif // >= 7.0
 }
+#ifdef ISIS_CUSTOM_ALARM_MSG
+void testCustomAlarmMessage()
+{
+    testDiag("testCustomAlarmMessage");
 
+    TestIOC IOC;
+
+    testdbReadDatabase("p2pTestIoc.dbd", NULL, NULL);
+    p2pTestIoc_registerRecordDeviceDriver(pdbbase);
+    testdbReadDatabase("test_custom_alarm.db", NULL, NULL);
+
+    aiRecord *prec_custom_ai = (aiRecord*)testdbRecordPtr("custom:ai");
+    testTrue(prec_custom_ai != NULL);
+
+    IOC.init();
+
+    DBCH chan_ai("custom:ai");
+
+    pvd::PVStructurePtr root;
+    p2p::auto_ptr<PVIF> pvif_ai;
+    {
+        ScalarBuilder builder_ai(chan_ai);
+
+        pvd::StructureConstPtr dtype_root(pvd::getFieldCreate()->createFieldBuilder()
+                                          ->add("custom_ai", builder_ai.dtype())
+                                          ->createStructure());
+
+        root = pvd::getPVDataCreate()->createPVStructure(dtype_root);
+        pvif_ai.reset(builder_ai.attach(root, FieldName("custom_ai")));
+    }
+
+    pvd::BitSet mask;
+
+    dbScanLock((dbCommon*)prec_custom_ai);
+    prec_custom_ai->val = 55.0;
+    dbProcess((dbCommon*)prec_custom_ai);
+    dbScanUnlock((dbCommon*)prec_custom_ai);
+
+    pvif_ai->put(mask, DBE_ALARM|DBE_PROPERTY, NULL);
+
+    testFieldEqual<pvd::PVString>(root, "custom_ai.alarm.message", "Custom Msg Alarm AI!");
+    testFieldEqual<pvd::PVInt>(root, "custom_ai.alarm.severity", 2);
+    testFieldEqual<pvd::PVInt>(root, "custom_ai.alarm.status", 1);
+
+    dbScanLock((dbCommon*)prec_custom_ai);
+    prec_custom_ai->val = 25.0;
+    dbProcess((dbCommon*)prec_custom_ai);
+    dbScanUnlock((dbCommon*)prec_custom_ai);
+    pvif_ai->put(mask, DBE_ALARM|DBE_PROPERTY, NULL);
+
+    testFieldEqual<pvd::PVString>(root, "custom_ai.alarm.message", "NO_ALARM");
+    testFieldEqual<pvd::PVInt>(root, "custom_ai.alarm.severity", 0);
+    testFieldEqual<pvd::PVInt>(root, "custom_ai.alarm.status", 0);
+}
+#endif // ISIS_CUSTOM_ALARM_MSG
 } // namespace
 
 MAIN(testpvif)
 {
+#ifdef ISIS_CUSTOM_ALARM_MSG
+    testPlan(105);
+#else
     testPlan(98);
+#endif    
 #ifdef USE_INT64
     testDiag("Testing of 64-bit field access");
 #else
@@ -651,5 +714,8 @@ MAIN(testpvif)
     testScalar();
     testPlain();
     testFilters();
+#ifdef ISIS_CUSTOM_ALARM_MSG
+    testCustomAlarmMessage();
+#endif
     return testDone();
 }


### PR DESCRIPTION
Summary
This PR includes modifications to enable the use of custom_alarm_msg.

Details

Updated relevant files to support custom_alarm_msg functionality.
This change was made to enable the use of long or alternate alarm messages. The alarm message will only be set if the corresponding INFO field is specified in the database (db) file. If the INFO field is not used, the behaviour remains exactly the same as the original pva2pva implementation. This approach allows existing systems to continue operating without any changes, while giving users the option to leverage extended alarm messages where necessary.

Testing

Confirmed existing tests pass.

Added/updated tests to cover custom alarm message handling (if applicable).